### PR TITLE
update repository link in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ development.  Things might break at any point.
 
 Currently we only support running Elsa with Cask.
 
-1. `git clone https://github.com/Fuco1/Elsa.git` somewhere to your computer.
+1. `git clone https://github.com/emacs-elsa/Elsa.git` somewhere to your computer.
 2. Add `(depends-on "elsa")` to `Cask` file of your project
 3. Run `cask link elsa <path-to-elsa-repo>`
 4. `cask exec elsa <file-to-analyse>` to analyse the file.  Currently


### PR DESCRIPTION
Just a minor change 😸 

BTW, It seems that coverage.io doesn't work with organisation link. You may need to update that as well.