### PR TITLE
Support multiple files passed on the command line

### DIFF
--- a/elsa.el
+++ b/elsa.el
@@ -125,10 +125,9 @@
 (defun elsa-run ()
   "Run `elsa-process-file' and output errors to stdout for flycheck."
   (elsa-load-config)
-  (let* ((file (car command-line-args-left))
-         (state (elsa-process-file file))
-         (errors (reverse (oref state errors))))
-    (--each errors (princ (elsa-message-format it)))))
+  (let ((file (car command-line-args-left)))
+    (--each (reverse (oref (elsa-process-file file) errors))
+      (princ (elsa-message-format it)))))
 
 (defun elsa-analyse-form (state form &optional type)
   "Analyse FORM in STATE.

--- a/elsa.el
+++ b/elsa.el
@@ -125,7 +125,7 @@
 (defun elsa-run ()
   "Run `elsa-process-file' and output errors to stdout for flycheck."
   (elsa-load-config)
-  (let ((file (car command-line-args-left)))
+  (dolist (file command-line-args-left)
     (--each (reverse (oref (elsa-process-file file) errors))
       (princ (concat file ":" (elsa-message-format it))))))
 

--- a/elsa.el
+++ b/elsa.el
@@ -127,7 +127,7 @@
   (elsa-load-config)
   (let ((file (car command-line-args-left)))
     (--each (reverse (oref (elsa-process-file file) errors))
-      (princ (elsa-message-format it)))))
+      (princ (concat file ":" (elsa-message-format it))))))
 
 (defun elsa-analyse-form (state form &optional type)
   "Analyse FORM in STATE.


### PR DESCRIPTION
Fix #132

This PR takes a naive approach and iterates the current logic over `command-line-args-left`. Basic messaging is added to indicate which file is being checked.

Probably should ultimately take a `file:line:col: message`, but I don't have enough knowledge yet of elsa internals to know where to store/retrieve `file`. It would clearly be a larger change, but I can give it a more involved go if that's also where you want to take it.