### PR TITLE
updates `elsa--read-cons` to correctly handle symbols starting with dot

### DIFF
--- a/elsa-reader.el
+++ b/elsa-reader.el
@@ -399,7 +399,7 @@ This only makes sense for the sequence forms:
                      (push head items)
                      (!cdr form)
                      (elsa--skip-whitespace-forward)
-                     (when (looking-at-p "\\.")
+                     (when (looking-at-p "\\.[^[:alnum:]]")
                        (forward-char 1)
                        (if (consp form)
                            (progn
@@ -426,7 +426,7 @@ This only makes sense for the sequence forms:
             (push (elsa--read-form (car form) state) items)
             (!cdr form)))
           (elsa--skip-whitespace-forward)
-          (when (and form (looking-at-p "\\."))
+          (when (and form (looking-at-p "\\.[^[:alnum:]]"))
             (if (elsa--quote-p (car form))
                 (forward-sexp) ;; skip the dot
               (cl-incf depth)


### PR DESCRIPTION
Fixes #172 by updating `elsa--read-cons` so that dots are only considered as dotted forms if not proceeded by an alphanumeric character.