### PR TITLE
Use `seq-take`, not `-take` for improper lists

### DIFF
--- a/elsa-reader.el
+++ b/elsa-reader.el
@@ -363,7 +363,7 @@ This only makes sense for the sequence forms:
 (cl-defmethod elsa-form-print ((this elsa-form-improper-list))
   (let* ((seq (oref this conses))
          (len (safe-length seq))
-         (prefix (-take len seq))
+         (prefix (seq-take seq len))
          (last (cdr (last seq))))
     (format "(%s . %s)"
             (mapconcat 'elsa-form-print prefix " ")
@@ -372,7 +372,7 @@ This only makes sense for the sequence forms:
 (cl-defmethod elsa-form-foreach ((this elsa-form-improper-list) fn)
   (let* ((seq (oref this conses))
          (len (safe-length seq))
-         (prefix (-take len seq))
+         (prefix (seq-take seq len))
          (last (cdr (last seq))))
     (mapc fn (-snoc prefix last))))
 


### PR DESCRIPTION
Due to an upstream change in dash.el 2.18 `-take` no longer works with
improper lists.

Not sure if there are other unintended consequences for this change, but it appears to fix the issue for me personally.

Breaking change in dash
https://github.com/magnars/dash.el/pull/354

Closes #176 