### PR TITLE
docs(README.md): Add another way to start Elsa with Eask

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,17 @@ Elsa can be run with [Eask][Eask], [makem.sh][makem] or [Cask][Cask].
 
 ## Eask
 
-### [RECOMMENDED] Using packaged version
+### [RECOMMENDED] Using packaged version  (via `lint`)
+
+The easiest way to execute Elsa with [Eask][Eask]:
+
+```
+eask lint elsa [PATTERNS]
+```
+
+`[PATTERNS]` is optional; the default will lint all your package files.
+
+### [RECOMMENDED] Using packaged version (via `exec`)
 
 This method uses [Eask][Eask] and installs Elsa from [MELPA][MELPA].
 
@@ -150,7 +160,7 @@ This method uses [Eask][Eask] and installs Elsa from [MELPA][MELPA].
 2. Run `eask install-deps`.
 3. `eask exec elsa FILE-TO-ANALYSE [ANOTHER-FILE...]` to analyse the file.
 
-### Using development version
+### Using development version (via `exec`)
 
 To use the development version of Elsa, you can clone the repository
 and use the `eask link` feature to use the code from the clone.


### PR DESCRIPTION
This is a question rather than a request.

There are already two methods to start Elsa with Eask, and here is `eask lint elsa ...`, the easiest (IMO)  way to start. Here are the pros and cos,

#### Pros

1. Elsa will be installed before the linting process
2. From Pt. 1, it's Easier for beginners
3. Better UX overall

#### Cons

1. People can get confuse with these many methods
2. One more place to think while developing Elsa

WDYT? Would you consider to support this method? If the answer is YES, I would like to add test for this method as well. ;)

BTW, there is a bug with this method right now, but only occurs in snapshots (`29.0.50` and `30.0.50`). See the log https://github.com/emacs-eask/cli/actions/runs/4191637568. Let me know if you want me to open an issue for this!