### PR TITLE
fix: Second argument of `mapconcat` should be sequence, not list

### DIFF
--- a/elsa-typed-builtin.el
+++ b/elsa-typed-builtin.el
@@ -210,7 +210,7 @@
 ;; (put 'clear-string 'elsa-type (elsa-make-type ))
 ;; (put 'nconc 'elsa-type (elsa-make-type ))
 ;; TODO: generic
-(put 'mapconcat 'elsa-type (elsa-make-type (function ((function (mixed) string) (list mixed) string) string)))
+(put 'mapconcat 'elsa-type (elsa-make-type (function ((function (mixed) string) sequence string) string)))
 ;; (put 'mapcar 'elsa-type (elsa-make-type ))
 ;; (put 'mapc 'elsa-type (elsa-make-type ))
 (put 'yes-or-no-p 'elsa-type (elsa-make-type (function (string) bool)))


### PR DESCRIPTION
Hi, Elsa! It is very interesting project for me. It is usually useful to apply static type analysis for Emacs Lisp.

I found that the second argument  `mapconcat` was `(list mixed)`, which should be `sequence`. 
This PR fix it.

Thanks.