### PR TITLE
Allow non-binding VARLIST entries in `let*`

### DIFF
--- a/elsa-analyser.el
+++ b/elsa-analyser.el
@@ -173,8 +173,9 @@ The BINDING should have one of the following forms:
     (-each bindings
       (lambda (binding)
         (let ((variable (elsa--analyse-variable-from-binding binding scope state)))
-          (push variable new-vars)
-          (elsa-scope-add-var scope variable))))
+          (when variable
+            (push variable new-vars)
+            (elsa-scope-add-var scope variable)))))
     (if (not body)
         (oset form type (elsa-type-nil))
       (elsa--analyse-body body scope state)


### PR DESCRIPTION
When VARLIST in `let*` is purely used for its side-effect and have no variable, do nothing.

For example, https://github.com/emacs-mirror/emacs/blob/73d2b829f06124fec8b65eebc68e87da48808086/lisp/comint.el#L3554